### PR TITLE
Bump typescript from 5.3.3 to 5.4.4 in the minor-patch group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "karma-jasmine-html-reporter": "~2.1.0",
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
-        "typescript": "~5.3.2"
+        "typescript": "~5.4.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12912,9 +12912,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
-    "typescript": "~5.3.2"
+    "typescript": "~5.4.4"
   },
   "lint-staged": {
     "*": "prettier --write --ignore-unknown"


### PR DESCRIPTION
Bumps the minor-patch group with 1 update: [typescript](https://github.com/Microsoft/TypeScript).


Updates `typescript` from 5.3.3 to 5.4.4
- [Release notes](https://github.com/Microsoft/TypeScript/releases)
- [Changelog](https://github.com/microsoft/TypeScript/blob/main/azure-pipelines.release.yml)
- [Commits](https://github.com/Microsoft/TypeScript/compare/v5.3.3...v5.4.4)

---
updated-dependencies:
- dependency-name: typescript dependency-type: direct:development update-type: version-update:semver-minor dependency-group: minor-patch ...